### PR TITLE
Pass parent reference of group view to item view

### DIFF
--- a/ampersand-grouped-collection-view.js
+++ b/ampersand-grouped-collection-view.js
@@ -71,7 +71,8 @@ module.exports = View.extend({
 
         var view = new this.itemView(extend({
             containerEl: this.currentGroupView.containerEl,
-            model: model
+            model: model,
+            parent: this.currentGroupView
         }, this.itemViewOptions));
         view.render();
         this.itemViews.push(view);


### PR DESCRIPTION
This allows for easy bubble-up event behavior. Such as "active" mode for a link that then "activates" the parent group as well.