### PR TITLE
Fix broken view removal

### DIFF
--- a/ampersand-grouped-collection-view.js
+++ b/ampersand-grouped-collection-view.js
@@ -1,5 +1,5 @@
 var extend = require('lodash.assign');
-var invoke = require('lodash.invoke');
+var invokeMap = require('lodash.invokeMap');
 var View = require('ampersand-view');
 
 
@@ -36,8 +36,8 @@ module.exports = View.extend({
     },
 
     removeAllViews: function () {
-        invoke(this.itemViews, 'remove');
-        invoke(this.groupViews, 'remove');
+        invokeMap(this.itemViews, 'remove');
+        invokeMap(this.groupViews, 'remove');
         this.itemViews = [];
         this.groupViews = [];
     },


### PR DESCRIPTION
Old lodash invoke function is now called invokeMap. Invoke function in 4.x executes a path on object, it dosen't work or do anything on an array, just fails silently. InvokeMap operates on an array/collection in the intended way here.